### PR TITLE
quick ugly fix: don't save m2m multiple times

### DIFF
--- a/admin_extend/extend.py
+++ b/admin_extend/extend.py
@@ -49,15 +49,17 @@ def add_bidirectional_m2m(form_cls):
             Returns ``instance``.
             """
             instance = super(BidirectionalM2MForm, self).save(commit=False)
-            force_save = self.instance.pk is None
-            if force_save:
-                instance.save()
-            for m2m_field, related_manager in self._get_bidirectional_m2m_fields():
-                setattr(self.instance, related_manager, self.cleaned_data[m2m_field])
-            if commit:
-                if not force_save:
+            if not hasattr(self,'_save_flag'):
+                self._save_flag=True
+                force_save = self.instance.pk is None
+                if force_save:
                     instance.save()
-                self.save_m2m()
+                for m2m_field, related_manager in self._get_bidirectional_m2m_fields():
+                    setattr(self.instance, related_manager, self.cleaned_data[m2m_field])
+                if commit:
+                    if not force_save:
+                        instance.save()
+                    self.save_m2m()
             return instance
 
     return BidirectionalM2MForm


### PR DESCRIPTION
When adding more than one extension, `save` will be called multiple times for all the fields.
When adding two extensions A and B, the saves will be ABAB instead of AB
When adding three extensions A, B and C, the saves will be ABCABCABC instead of ABC

In this image one can see that for every derivated class the save is called. Since the fields() is overriden the save is called for each of the m2m fields => n**2 saves
![multiple m2m save issue](https://cloud.githubusercontent.com/assets/520767/5011286/bd5b1ffc-6a84-11e4-9fe0-a327b2700540.png)

I took some time but couldn't find a better solution, besides skipping the other saves.

